### PR TITLE
[EX-10178] Bump dependency for CVE (maybe)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     python_requires=">=3.7",
     install_requires=[
         "pipelinewise-singer-python~=1.0",
-        "snowflake-connector-python[pandas]~=3.10.0",
+        "snowflake-connector-python[pandas]~=3.12.0",
         "inflection~=0.5.1",
         "joblib~=1.2.0",
         "boto3~=1.28.20",

--- a/setup.py
+++ b/setup.py
@@ -2,43 +2,44 @@
 
 from setuptools import find_packages, setup
 
-with open('README.md') as f:
+with open("README.md") as f:
     long_description = f.read()
 
-setup(name="pipelinewise-target-snowflake",
-      version="2.3.1",
-      description="Singer.io target for loading data to Snowflake - PipelineWise compatible",
-      long_description=long_description,
-      long_description_content_type='text/markdown',
-      author="Wise",
-      url='https://github.com/transferwise/pipelinewise-target-snowflake',
-      classifiers=[
-          'License :: OSI Approved :: Apache Software License',
-          'Programming Language :: Python :: 3 :: Only',
-          'Programming Language :: Python :: 3.7',
-          'Programming Language :: Python :: 3.8',
-          'Programming Language :: Python :: 3.9',
-      ],
-      py_modules=["target_snowflake"],
-      python_requires='>=3.7',
-      install_requires=[
-          'pipelinewise-singer-python~=1.0',
-          'snowflake-connector-python[pandas]~=3.10.0',
-          'inflection~=0.5.1',
-          'joblib~=1.2.0',
-          'boto3~=1.28.20',
-      ],
-      extras_require={
-          "test": [
-              "pylint==2.12.*",
-              'pytest==7.4.0',
-              'pytest-cov==3.0.0',
-              "python-dotenv>=0.19,<1.1"
-          ]
-      },
-      entry_points="""
+setup(
+    name="pipelinewise-target-snowflake",
+    version="2.3.1",
+    description="Singer.io target for loading data to Snowflake - PipelineWise compatible",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    author="Wise",
+    url="https://github.com/transferwise/pipelinewise-target-snowflake",
+    classifiers=[
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+    ],
+    py_modules=["target_snowflake"],
+    python_requires=">=3.7",
+    install_requires=[
+        "pipelinewise-singer-python~=1.0",
+        "snowflake-connector-python[pandas]~=3.10.0",
+        "inflection~=0.5.1",
+        "joblib~=1.2.0",
+        "boto3~=1.28.20",
+    ],
+    extras_require={
+        "test": [
+            "pylint==2.12.*",
+            "pytest==7.4.0",
+            "pytest-cov==3.0.0",
+            "python-dotenv>=0.19,<1.1",
+        ]
+    },
+    entry_points="""
           [console_scripts]
           target-snowflake=target_snowflake:main
       """,
-      packages=find_packages(exclude=['tests*']),
-      )
+    packages=find_packages(exclude=["tests*"]),
+)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md") as f:
 
 setup(
     name="pipelinewise-target-snowflake",
-    version="2.3.1",
+    version="2.3.3",
     description="Singer.io target for loading data to Snowflake - PipelineWise compatible",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Problem

There's a CVE w/ `urllib3` in the `target-snowflake` plugin, and I think I've traced it back to this package. Hard to be sure! If this doesn't work, I'll just apply for a waiver until Snowflake officially retired at WG.

[CVE-2024-37891](https://nvd.nist.gov/vuln/detail/CVE-2024-37891)

One question: How do we "publish" the new package version -- just tag it on GitHub?

## Proposed changes

- bump `snowflake-connector-python` from v3.10 => v3.12
- bump this pkg version

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions